### PR TITLE
Develop

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches: [main, develop]
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
   schedule:
-    - cron: '0 0 * * 0'  # Weekly dependency check
+    - cron: "0 0 * * 0" # Weekly dependency check
 
 env:
   CARGO_TERM_COLOR: always
@@ -51,7 +51,7 @@ jobs:
           fi
           echo "msrv=$MSRV" >> $GITHUB_OUTPUT
           echo "Using MSRV: $MSRV"
-      
+
       - name: Install Rust ${{ steps.msrv.outputs.msrv }}
         uses: dtolnay/rust-toolchain@master
         with:
@@ -74,7 +74,7 @@ jobs:
         run: cargo +nightly udeps --all-targets --all-features
 
   semver_check:
-    name: Semantic Versioning Check  
+    name: Semantic Versioning Check
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/v')
     steps:
@@ -113,19 +113,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      
+
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rust-docs
-      
+
       - uses: Swatinem/rust-cache@v2
-      
+
       - name: Build documentation with broken link check
         run: |
           RUSTDOCFLAGS="-D warnings -D rustdoc::broken_intra_doc_links --cfg docsrs" \
           cargo +nightly doc --all-features --no-deps
-      
+
       - name: Verify docs directory exists
         run: |
           if [ ! -d "./target/doc" ]; then
@@ -144,12 +144,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      
+
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
-      
+
       - uses: Swatinem/rust-cache@v2
-      
+
       - name: Check version match
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/v}
@@ -158,16 +158,16 @@ jobs:
             echo "::error::Version mismatch: Tag version ($TAG_VERSION) does not match Cargo.toml version ($CARGO_VERSION)"
             exit 1
           fi
-      
+
       - name: Check changelog update
         run: |
           CARGO_VERSION=$(grep -m 1 '^version =' Cargo.toml | cut -d'"' -f2)
           grep -q "$CARGO_VERSION" CHANGELOG.md || (echo "::error::No entry for version $CARGO_VERSION in CHANGELOG.md" && exit 1)
-      
+
       - name: Verify Edition 2024 in Cargo.toml
         run: |
           grep -q 'edition = "2024"' Cargo.toml || (echo "::error::Edition 2024 not found in Cargo.toml" && exit 1)
-      
+
       - name: Publish to crates.io
         uses: katyo/publish-crates@v2
         with:
@@ -187,11 +187,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      
+
       - name: Get version from tag
         id: get_version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-        
+
       - name: Extract version section from CHANGELOG.md
         id: extract_changelog
         run: |
@@ -210,7 +210,7 @@ jobs:
           echo "body<<EOF" >> $GITHUB_OUTPUT
           echo "$BODY" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-    
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
@@ -229,37 +229,39 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0
-      
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-      
+
       - uses: Swatinem/rust-cache@v2
-      
+
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y jq
-      
+
       - name: Run benchmarks
         run: |
-          cargo bench --all-features -- --output-format json > benchmark_raw_results.json || {
+          cargo bench --all-features -- --output-format json | tee benchmark_raw_results.json || {
             echo "::warning::Benchmark execution failed with error code $?"
             echo "[]" > benchmark_raw_results.json
           }
-          
+
       - name: Process benchmark results
         run: |
           if [ -f benchmark_raw_results.json ] && [ -s benchmark_raw_results.json ]; then
-            jq -r '.[] | select(.reason == "benchmark-complete") | {
+            jq -c '[.[] | select(.reason == "benchmark-complete") | {
               "name": .id,
               "value": .median,
               "unit": "ns/iter"
-            }' benchmark_raw_results.json > formatted_benchmark_results.json || {
+            }]' benchmark_raw_results.json > formatted_benchmark_results.json || {
               echo "::warning::Failed to process benchmark results with error code $?"
               echo "[]" > formatted_benchmark_results.json
             }
@@ -267,16 +269,54 @@ jobs:
             echo "::warning::No benchmark results found, creating empty results"
             echo "[]" > formatted_benchmark_results.json
           fi
-      
-      - name: Upload benchmark results
+
+          # Validate JSON format
+          jq empty formatted_benchmark_results.json || {
+            echo "::error::Invalid JSON in benchmark results"
+            echo "[]" > formatted_benchmark_results.json
+          }
+
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Setup gh-pages structure
+        run: |
+          mkdir -p gh-pages/benchmarks
+          if [ ! -f gh-pages/benchmarks/index.html ]; then
+            cat > gh-pages/benchmarks/index.html << 'EOF'
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>Benchmark Results</title>
+              <meta charset="utf-8">
+          </head>
+          <body>
+              <h1>Performance Benchmarks</h1>
+              <div id="benchmark-chart"></div>
+              <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+          </body>
+          </html>
+          EOF
+          fi
+
+      - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Rust Benchmarks
-          tool: 'customSmallerIsBetter'
+          tool: "customSmallerIsBetter"
           output-file-path: formatted_benchmark_results.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: false
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: benchmarks
+          auto-push: true
           comment-on-alert: true
-          alert-threshold: '120%'
+          alert-threshold: "120%"
           fail-on-alert: false
-          alert-comment-cc-users: '@${{ github.repository_owner }}'
+          alert-comment-cc-users: "@${{ github.repository_owner }}"
+          gh-repository: ${{ github.repository }}
+          skip-fetch-gh-pages: false

--- a/src/datatypes/maybe.rs
+++ b/src/datatypes/maybe.rs
@@ -51,9 +51,6 @@
 //! - **Compositional Logic**: Enables clean composition of operations that might fail without
 //!   explicit conditional statements
 //!
-//! - **Short-Circuit Evaluation**: Automatically propagates failure states (`Nothing`) through
-//!   computation chains, similar to how Rust's `?` operator works
-//!
 //! Similar constructs in other functional languages include:
 //!
 //! - Haskell's `Maybe` type with `Just` and `Nothing` constructors
@@ -65,7 +62,6 @@
 //! # Key Features
 //!
 //! - **Failure Handling**: Represents computations that might not return a value
-//! - **Short-circuiting**: Operations on `Nothing` propagate the `Nothing` value
 //! - **Composition**: Chain operations together without explicit null checks
 //!
 //! # Common Use Cases

--- a/src/transformers/reader_t.rs
+++ b/src/transformers/reader_t.rs
@@ -240,21 +240,20 @@ pub type ReaderCombineFn<Env, M1, A1, B1, C1> =
 /// assert_eq!(result, vec![5, 5]);
 /// ```
 pub struct ReaderT<E, M, A> {
-    /// Internal function that runs with an environment to produce a monadic value
     run_reader_fn: Arc<dyn Fn(E) -> M + Send + Sync>,
-    /// Phantom data to track the value type
-    phantom: PhantomData<A>,
+    _phantom: PhantomData<A>,
 }
 
 impl<E, M, A> Clone for ReaderT<E, M, A>
 where
     E: 'static,
     M: 'static,
+    A: Clone,
 {
     fn clone(&self) -> Self {
         ReaderT {
-            run_reader_fn: self.run_reader_fn.clone(),
-            phantom: PhantomData,
+            run_reader_fn: Arc::clone(&self.run_reader_fn),
+            _phantom: PhantomData,
         }
     }
 }
@@ -299,7 +298,7 @@ where
     {
         ReaderT {
             run_reader_fn: Arc::new(f),
-            phantom: PhantomData,
+            _phantom: PhantomData,
         }
     }
 
@@ -430,7 +429,7 @@ where
     where
         F: Fn(E) -> E + Send + Sync + 'static,
     {
-        let inner_fn = self.run_reader_fn.clone();
+        let inner_fn = Arc::clone(&self.run_reader_fn);
         ReaderT::new(move |e| inner_fn(f(e)))
     }
 
@@ -638,7 +637,7 @@ where
         B: 'static,
         M: 'static,
     {
-        let inner_fn = self.run_reader_fn.clone();
+        let inner_fn = Arc::clone(&self.run_reader_fn);
         let f_clone = f;
 
         ReaderT::new(move |e| {
@@ -700,7 +699,7 @@ where
         M: 'static,
         N: 'static,
     {
-        let inner_fn = self.run_reader_fn.clone();
+        let inner_fn = Arc::clone(&self.run_reader_fn);
         let f_clone = f.clone();
 
         ReaderT::new(move |e: E| {
@@ -739,8 +738,8 @@ where
         B: 'static,
         M: 'static,
     {
-        let self_fn = self.run_reader_fn.clone();
-        let f_fn = f.run_reader_fn.clone();
+        let self_fn = Arc::clone(&self.run_reader_fn);
+        let f_fn = Arc::clone(&f.run_reader_fn);
         let ap_fn_clone = ap_fn.clone();
 
         ReaderT::new(move |e: E| {
@@ -777,8 +776,8 @@ where
         let combine_fn_clone = combine_fn.clone();
         Box::new(
             move |reader1: &ReaderT<E, M, A>, reader2: &ReaderT<E, M, B>| {
-                let run1 = reader1.run_reader_fn.clone();
-                let run2 = reader2.run_reader_fn.clone();
+                let run1 = Arc::clone(&reader1.run_reader_fn);
+                let run2 = Arc::clone(&reader2.run_reader_fn);
                 let f_clone = f_clone.clone();
                 let combine_fn_inner = combine_fn_clone.clone();
                 ReaderT::new(move |e: E| {
@@ -819,8 +818,8 @@ where
         C: Clone + 'static,
         M: HKT<Output<C> = M>,
     {
-        let self_fn = self.run_reader_fn.clone();
-        let other_fn = other.run_reader_fn.clone();
+        let self_fn = Arc::clone(&self.run_reader_fn);
+        let other_fn = Arc::clone(&other.run_reader_fn);
         let f = Arc::new(f);
         let combine_fn = Arc::new(combine_fn);
 
@@ -908,7 +907,7 @@ where
         B: Clone + 'static,
         M: HKT<Output<B> = M>,
     {
-        let reader_fn = self.run_reader_fn.clone();
+        let reader_fn = Arc::clone(&self.run_reader_fn);
 
         ReaderT::new(move |e: E| {
             let ma = reader_fn(e);

--- a/src/transformers/reader_t.rs
+++ b/src/transformers/reader_t.rs
@@ -248,7 +248,6 @@ impl<E, M, A> Clone for ReaderT<E, M, A>
 where
     E: 'static,
     M: 'static,
-    A: Clone,
 {
     fn clone(&self) -> Self {
         ReaderT {


### PR DESCRIPTION
IO Type Refactor: The IO type has been transformed from a struct wrapping a function into an enum (Pure or Effect), allowing for explicit representation of immediate values versus deferred computations. This change impacts how IO operations are constructed, run, mapped, and bound.

StateT Type Refactor: The StateT monad transformer has been similarly refactored into an enum (Pure, LiftM, or Effect), providing clearer semantics for state transformations, including pure results and lifted monadic values. This required extensive updates to its core methods like run_state, map, and bind.

Consistent Arc::clone Usage: In ReaderT and other types, the usage of Arc::clone has been made more explicit by consistently writing Arc::clone(&self.field) instead of self.field.clone(), which is a minor stylistic and clarity improvement for Arc handling.

Documentation Cleanup: Redundant documentation regarding 'short-circuit evaluation' has been removed from the Maybe type's description, streamlining its explanation.