### PR TITLE
Refactor/pvec for 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 - **PVec Structural Sharing in `Extend`**: Preserved structural sharing in `Extend::extend` via amortized $O(1)$ tail pushes (`push_back`), eliminating full-vector heap reallocations and tree rebuilds.
 - **PVec Debug Trait Bound & Formatting**: Relaxed `Debug` bound on `PersistentVector<T>` from `T: Clone + Debug` to `T: Debug`, enabling non-clone element formatting and standardizing output to list format (`[...]`).
 - **PVec Invariants & Inline Fast-Paths**: Enforced uniform branch height in `concat_nodes` via `unreachable!`, and added direct in-place `SmallVec` fast-paths for `insert` and `remove` on `Inline` vectors ($\le 64$ elements).
+- **PVec Projection Bound Relaxation**: Removed unnecessary `U: Clone` bound from `PersistentVector::map`, `filter_map`, and `flat_map`.
+- **PVec Lazy Value Iteration**: Replaced eager full-vector heap allocation in `PersistentVectorIntoIter` with on-demand leaf streaming.
+- **PVec Equivalence and Removal Fast-Paths**: Added length and `Arc::ptr_eq` short-circuits to `PartialEq::eq`, $O(1)$ boundary removal (`pop_front`/`pop_back`) in `PersistentVector::remove`, and direct collection in `PersistentVector::chunk`.
+- **PVec Internal Derives & Error Cleanup**: Removed unused `PartialEq, Eq, PartialOrd, Ord, Hash` derives from internal `VectorImpl`, `RRBTree`, and `RRBNode`; deprecated `PVecError::is_index_out_of_bounds` in favor of pattern matching.
 - **Vec Alternative Monoidal Semantics**: Changed `<Vec<T> as Alternative>::alt` from first-non-empty semantics to monoidal concatenation (`self.extend(other)`).
 
 ### Free Monad (`Free<F, A>`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - **AsRef Panic Removal**: Removed panicking `AsRef` implementations from `First` and `Last` in favor of non-panicking `get()` and `into_value()`.
 - **IO::delay Reactor Nesting**: Resolved Tokio thread panics caused by nested `block_on` runtime invocations in `IO::delay`.
 - **PVec Reversal and Height Reset**: Fixed order reversal and height loss bugs in `pop_front_from_tree` within `src/pvec/tree.rs`.
+- **PVec Single-Pass Tree Pop**: Optimized `pop_from_tree` in `src/pvec/tree.rs` to consume popped values directly from `root.pop_back()`, removing redundant $O(\log n)$ tree lookups and duplicate clones.
+- **PVec Structural Sharing in `Extend`**: Preserved structural sharing in `Extend::extend` via amortized $O(1)$ tail pushes (`push_back`), eliminating full-vector heap reallocations and tree rebuilds.
+- **PVec Debug Trait Bound & Formatting**: Relaxed `Debug` bound on `PersistentVector<T>` from `T: Clone + Debug` to `T: Debug`, enabling non-clone element formatting and standardizing output to list format (`[...]`).
+- **PVec Invariants & Inline Fast-Paths**: Enforced uniform branch height in `concat_nodes` via `unreachable!`, and added direct in-place `SmallVec` fast-paths for `insert` and `remove` on `Inline` vectors ($\le 64$ elements).
 - **Vec Alternative Monoidal Semantics**: Changed `<Vec<T> as Alternative>::alt` from first-non-empty semantics to monoidal concatenation (`self.extend(other)`).
 
 ### Free Monad (`Free<F, A>`)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Rustica provides pragmatic functional programming and category theory abstractio
 - **Domain Modeling**: Eliminate impossible states at compile time
 - **Validation**: Accumulate multiple errors without early termination (`Validated`)
 - **Effect Isolation**: Manage state, dependencies, and I/O explicitly (`IO`, `State`, `Reader`)
-- **Persistent Data**: High-performance immutable collections with structural sharing (`PersistentVector`)
+- **Persistent Data**: Immutable collections with structural sharing (`PersistentVector`)
 
 ---
 

--- a/src/pvec/core.rs
+++ b/src/pvec/core.rs
@@ -12,17 +12,13 @@ use super::tree::RRBTree;
 
 pub(crate) const ADAPTIVE_INLINE_SIZE: usize = 64;
 
-/// A persistent, immutable vector data structure.
+/// An immutable vector data structure with structural sharing.
 ///
-/// `PersistentVector` provides an efficient implementation of an immutable vector
-/// that supports structural sharing. Operations like `push_back`, `push_front`,
-/// and `update` return new vectors that share structure with the original,
-/// making them efficient in both time and space.
+/// Operations like `push_back`, `push_front`, and `update` return new vectors
+/// that share unchanged nodes with the original.
 ///
-/// The implementation uses an adaptive strategy: small vectors are stored inline
-/// for optimal performance, while larger vectors use an RRB (Relaxed Radix Balanced)
-/// tree structure that provides logarithmic time complexity for most operations.
-///
+/// Storage is adaptive: vectors with $\le 64$ elements reside in inline storage,
+/// while larger vectors use an RRB (Relaxed Radix Balanced) tree.
 #[derive(Clone)]
 pub struct PersistentVector<T> {
     pub(crate) inner: VectorImpl<T>,
@@ -32,7 +28,7 @@ pub struct PersistentVector<T> {
 ///
 /// Uses an adaptive strategy where small vectors are stored inline
 /// and larger vectors use a tree structure.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug)]
 pub(crate) enum VectorImpl<T> {
     /// Inline storage for small vectors.
     Inline {
@@ -53,6 +49,15 @@ impl<T> VectorImpl<T> {
 
 impl<T: PartialEq> PartialEq for PersistentVector<T> {
     fn eq(&self, other: &Self) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+        if let (VectorImpl::Tree { tree: t1 }, VectorImpl::Tree { tree: t2 }) =
+            (&self.inner, &other.inner)
+            && Arc::ptr_eq(t1, t2)
+        {
+            return true;
+        }
         self.iter().eq(other.iter())
     }
 }
@@ -208,7 +213,6 @@ impl<T: Clone> PersistentVector<T> {
     pub fn map<U, F>(&self, f: F) -> PersistentVector<U>
     where
         F: Fn(&T) -> U,
-        U: Clone,
     {
         PersistentVector::from_iter(self.iter().map(f))
     }
@@ -224,7 +228,7 @@ impl<T: Clone> PersistentVector<T> {
 
     /// Creates a new vector by applying a function and filtering out `None` results.
     ///
-    pub fn filter_map<U: Clone, F>(&self, f: F) -> PersistentVector<U>
+    pub fn filter_map<U, F>(&self, f: F) -> PersistentVector<U>
     where
         F: Fn(&T) -> Option<U>,
     {
@@ -242,7 +246,7 @@ impl<T: Clone> PersistentVector<T> {
     /// let doubled = vec.flat_map(|&x| vec![x, x]);
     /// assert_eq!(doubled.to_vec(), vec![1, 1, 2, 2, 3, 3]);
     /// ```
-    pub fn flat_map<U: Clone, F, I>(&self, f: F) -> PersistentVector<U>
+    pub fn flat_map<U, F, I>(&self, f: F) -> PersistentVector<U>
     where
         F: Fn(&T) -> I,
         I: IntoIterator<Item = U>,
@@ -362,8 +366,8 @@ impl<T: Clone> PersistentVector<T> {
 
         let mut iter = self.iter();
         PersistentVector::from_iter(std::iter::from_fn(move || {
-            let chunk: Vec<T> = iter.by_ref().take(size).cloned().collect();
-            (!chunk.is_empty()).then(|| PersistentVector::from_iter(chunk))
+            let chunk: PersistentVector<T> = iter.by_ref().take(size).cloned().collect();
+            (!chunk.is_empty()).then_some(chunk)
         }))
     }
 
@@ -633,6 +637,13 @@ impl<T: Clone> PersistentVector<T> {
             return Some(Self::inline(new_elements));
         }
 
+        if index == 0 {
+            return self.pop_front().map(|(v, _)| v);
+        }
+        if index == self.len() - 1 {
+            return self.pop_back().map(|(v, _)| v);
+        }
+
         let (left, right) = self.split_at(index);
         let right_without_first = right.split_at(1).1;
         Some(left.concat(&right_without_first))
@@ -724,9 +735,7 @@ impl<T: Clone> IntoIterator for PersistentVector<T> {
     type IntoIter = PersistentVectorIntoIter<T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        PersistentVectorIntoIter {
-            iter: self.into_vec().into_iter(),
-        }
+        PersistentVectorIntoIter::new(self)
     }
 }
 
@@ -768,6 +777,22 @@ mod read_only_non_clone_tests {
         assert_eq!(v.fold(0, |acc, x| acc + x.0), 42);
     }
 
+    #[test]
+    fn mapping_supports_non_clone_output_type() {
+        let v = PersistentVector::from_slice(&[1, 2, 3]);
+        let mapped = v.map(|&x| NonClone(x));
+        assert_eq!(mapped.len(), 3);
+        assert_eq!(mapped.get(1).map(|x| x.0), Some(2));
+
+        let filtered = v.filter_map(|&x| (x > 1).then_some(NonClone(x)));
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered.get(0).map(|x| x.0), Some(2));
+
+        let flattened = v.flat_map(|&x| [NonClone(x), NonClone(x * 10)]);
+        assert_eq!(flattened.len(), 6);
+        assert_eq!(flattened.get(1).map(|x| x.0), Some(10));
+    }
+
     #[derive(Debug, PartialEq, Eq)]
     struct NonCloneDebug(i32);
 
@@ -806,5 +831,44 @@ mod read_only_non_clone_tests {
         let removed = v.remove(2).expect("valid index");
         assert_eq!(removed.to_vec(), vec![1, 2, 3, 4]);
         assert!(matches!(removed.inner, VectorImpl::Inline { .. }));
+    }
+
+    #[test]
+    fn test_eq_fast_path() {
+        let v1: PersistentVector<i32> = (0..100).collect();
+        let v2 = v1.clone();
+        assert_eq!(v1, v2);
+
+        let v3: PersistentVector<i32> = (0..99).collect();
+        assert_ne!(v1, v3);
+    }
+
+    #[test]
+    fn test_chunk_direct() {
+        let v: PersistentVector<i32> = (0..10).collect();
+        let chunks = v.chunk(3);
+        assert_eq!(chunks.len(), 4);
+        assert_eq!(chunks[0].to_vec(), vec![0, 1, 2]);
+        assert_eq!(chunks[1].to_vec(), vec![3, 4, 5]);
+        assert_eq!(chunks[2].to_vec(), vec![6, 7, 8]);
+        assert_eq!(chunks[3].to_vec(), vec![9]);
+
+        let empty = PersistentVector::<i32>::new().chunk(5);
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn test_lazy_into_iter_interleaved() {
+        let v: PersistentVector<i32> = (0..200).collect();
+        let mut it = v.into_iter();
+        assert_eq!(it.next(), Some(0));
+        assert_eq!(it.next_back(), Some(199));
+        assert_eq!(it.next(), Some(1));
+        assert_eq!(it.next_back(), Some(198));
+        assert_eq!(it.len(), 196);
+
+        let remaining: Vec<i32> = it.collect();
+        assert_eq!(remaining.len(), 196);
+        assert_eq!(remaining, (2..198).collect::<Vec<_>>());
     }
 }

--- a/src/pvec/core.rs
+++ b/src/pvec/core.rs
@@ -380,7 +380,7 @@ impl<T: Clone> PersistentVector<T> {
                     self.transition_to_tree().push_back(value)
                 }
             },
-            VectorImpl::Tree { tree: _ } => self.tree_push_back(value),
+            VectorImpl::Tree { tree } => Self::tree(tree.push_back(value)),
         }
     }
 
@@ -398,7 +398,7 @@ impl<T: Clone> PersistentVector<T> {
                     self.transition_to_tree().push_front(value)
                 }
             },
-            VectorImpl::Tree { tree: _ } => self.tree_push_front(value),
+            VectorImpl::Tree { tree } => Self::tree(tree.push_front(value)),
         }
     }
 
@@ -480,28 +480,6 @@ impl<T: Clone> PersistentVector<T> {
         }
     }
 
-    /// Pushes a value to the back of a tree-based vector.
-    fn tree_push_back(&self, value: T) -> Self {
-        match &self.inner {
-            VectorImpl::Tree { tree } => {
-                let new_tree = tree.push_back(value);
-                Self::tree(new_tree)
-            },
-            _ => unreachable!(),
-        }
-    }
-
-    /// Pushes a value to the front of a tree-based vector.
-    fn tree_push_front(&self, value: T) -> Self {
-        match &self.inner {
-            VectorImpl::Tree { tree } => {
-                let new_tree = tree.push_front(value);
-                Self::tree(new_tree)
-            },
-            _ => unreachable!(),
-        }
-    }
-
     /// Creates a new vector by concatenating this vector with another.
     ///
     pub fn concat(&self, other: &Self) -> Self {
@@ -520,20 +498,9 @@ impl<T: Clone> PersistentVector<T> {
                 let merged_tree = tree.concat(&right_tree);
                 Self::tree(merged_tree)
             },
-            (VectorImpl::Tree { .. }, VectorImpl::Tree { .. }) => {
-                let left_tree = self.ensure_tree();
-                let right_tree = other.ensure_tree();
-                let merged_tree = left_tree.concat(&right_tree);
-                Self::tree(merged_tree)
+            (VectorImpl::Tree { tree: left }, VectorImpl::Tree { tree: right }) => {
+                Self::tree(left.concat(right))
             },
-        }
-    }
-
-    /// Ensures the vector is in tree form, converting if necessary.
-    fn ensure_tree(&self) -> RRBTree<T> {
-        match &self.inner {
-            VectorImpl::Inline { elements } => RRBTree::from_elements(elements.iter().cloned()),
-            VectorImpl::Tree { tree } => (**tree).clone(),
         }
     }
 
@@ -635,6 +602,14 @@ impl<T: Clone> PersistentVector<T> {
             return self.push_front(value);
         }
 
+        if let VectorImpl::Inline { elements } = &self.inner
+            && elements.len() < ADAPTIVE_INLINE_SIZE
+        {
+            let mut new_elements = elements.clone();
+            new_elements.insert(index, value);
+            return Self::inline(new_elements);
+        }
+
         let (left, right) = self.split_at(index);
         left.push_back(value).concat(&right)
     }
@@ -650,6 +625,12 @@ impl<T: Clone> PersistentVector<T> {
 
         if self.len() == 1 {
             return Some(Self::new());
+        }
+
+        if let VectorImpl::Inline { elements } = &self.inner {
+            let mut new_elements = elements.clone();
+            new_elements.remove(index);
+            return Some(Self::inline(new_elements));
         }
 
         let (left, right) = self.split_at(index);
@@ -720,8 +701,9 @@ impl<T> FromIterator<T> for PersistentVector<T> {
 
 impl<T: Clone> Extend<T> for PersistentVector<T> {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        let current = std::mem::take(self);
-        *self = current.into_iter().chain(iter).collect();
+        for item in iter {
+            *self = self.push_back(item);
+        }
     }
 }
 
@@ -765,21 +747,9 @@ impl<T> std::ops::Index<usize> for PersistentVector<T> {
     }
 }
 
-impl<T: Clone + Debug> Debug for PersistentVector<T> {
+impl<T: Debug> Debug for PersistentVector<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.inner {
-            VectorImpl::Inline { elements } => {
-                write!(
-                    f,
-                    "PersistentVector(Inline, len={}, elements={:?})",
-                    self.len(),
-                    elements.as_slice()
-                )
-            },
-            VectorImpl::Tree { .. } => {
-                write!(f, "PersistentVector(Tree, len={})", self.len())
-            },
-        }
+        f.debug_list().entries(self.iter()).finish()
     }
 }
 
@@ -796,5 +766,45 @@ mod read_only_non_clone_tests {
         assert_eq!(v.last().map(|x| x.0), Some(42));
         assert_eq!(v.try_get(0).map(|x| x.0), Ok(42));
         assert_eq!(v.fold(0, |acc, x| acc + x.0), 42);
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct NonCloneDebug(i32);
+
+    #[test]
+    fn test_debug_non_clone() {
+        let v = PersistentVector::single(NonCloneDebug(42));
+        assert_eq!(format!("{v:?}"), "[NonCloneDebug(42)]");
+    }
+
+    #[test]
+    fn test_debug_tree_elements() {
+        let v: PersistentVector<i32> = (0..100).collect();
+        let expected = format!("{:?}", (0..100).collect::<Vec<_>>());
+        assert_eq!(format!("{v:?}"), expected);
+    }
+
+    #[test]
+    fn test_extend_preserves_elements() {
+        let mut v: PersistentVector<i32> = (0..1000).collect();
+        v.extend(1000..1005);
+        assert_eq!(v.len(), 1005);
+        assert_eq!(v.to_vec(), (0..1005).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_inline_insert_fast_path() {
+        let v = PersistentVector::from_slice(&[1, 2, 4, 5]);
+        let inserted = v.insert(2, 3);
+        assert_eq!(inserted.to_vec(), vec![1, 2, 3, 4, 5]);
+        assert!(matches!(inserted.inner, VectorImpl::Inline { .. }));
+    }
+
+    #[test]
+    fn test_inline_remove_fast_path() {
+        let v = PersistentVector::from_slice(&[1, 2, 99, 3, 4]);
+        let removed = v.remove(2).expect("valid index");
+        assert_eq!(removed.to_vec(), vec![1, 2, 3, 4]);
+        assert!(matches!(removed.inner, VectorImpl::Inline { .. }));
     }
 }

--- a/src/pvec/error.rs
+++ b/src/pvec/error.rs
@@ -14,6 +14,10 @@ impl PVecError {
         Self::IndexOutOfBounds { index, len }
     }
 
+    #[deprecated(
+        since = "0.16.0",
+        note = "use pattern matching on `PVecError::IndexOutOfBounds` instead"
+    )]
     #[inline]
     pub const fn is_index_out_of_bounds(&self) -> bool {
         matches!(self, Self::IndexOutOfBounds { .. })

--- a/src/pvec/iter.rs
+++ b/src/pvec/iter.rs
@@ -28,8 +28,8 @@
 use smallvec::SmallVec;
 use std::sync::Arc;
 
-use super::core::{PersistentVector, VectorImpl};
-use super::node::{RRBNode, SMALL_BRANCH_SIZE};
+use super::core::{ADAPTIVE_INLINE_SIZE, PersistentVector, VectorImpl};
+use super::node::{LEAF_CAPACITY, RRBNode, SMALL_BRANCH_SIZE};
 use super::tree::RRBTree;
 
 /// Stack entry for tree traversal.
@@ -462,33 +462,136 @@ impl<'a, T> TreeIterState<'a, T> {
 
 /// An iterator that yields owned elements from a persistent vector.
 ///
-/// This iterator consumes the vector and yields owned values.
-///
-/// # Note
-///
-/// This iterator requires `T: Clone` because elements are cloned from the
-/// underlying storage to produce owned values.
-///
+/// This iterator consumes the vector and yields owned values lazily
+/// without eagerly materializing the entire vector as a `Vec<T>`.
 pub struct PersistentVectorIntoIter<T> {
-    pub(crate) iter: std::vec::IntoIter<T>,
+    state: IntoIterState<T>,
+    remaining: usize,
 }
 
-impl<T> Iterator for PersistentVectorIntoIter<T> {
+enum IntoIterState<T> {
+    Inline(smallvec::IntoIter<[T; ADAPTIVE_INLINE_SIZE]>),
+    Tree(Box<TreeIntoIterState<T>>),
+    Done,
+}
+
+struct TreeIntoIterState<T> {
+    tree: Arc<RRBTree<T>>,
+    front_index: usize,
+    front_leaf: SmallVec<[T; LEAF_CAPACITY]>,
+    front_pos: usize,
+    back_index: usize,
+    back_leaf: SmallVec<[T; LEAF_CAPACITY]>,
+}
+
+impl<T: Clone> PersistentVectorIntoIter<T> {
+    pub(crate) fn new(vector: PersistentVector<T>) -> Self {
+        let remaining = vector.len();
+        if remaining == 0 {
+            return Self {
+                state: IntoIterState::Done,
+                remaining: 0,
+            };
+        }
+
+        let state = match vector.inner {
+            VectorImpl::Inline { elements } => IntoIterState::Inline(elements.into_iter()),
+            VectorImpl::Tree { tree } => IntoIterState::Tree(Box::new(TreeIntoIterState {
+                front_index: 0,
+                front_leaf: SmallVec::new(),
+                front_pos: 0,
+                back_index: tree.len,
+                back_leaf: SmallVec::new(),
+                tree,
+            })),
+        };
+
+        Self { state, remaining }
+    }
+}
+
+impl<T: Clone> Iterator for PersistentVectorIntoIter<T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
+        if self.remaining == 0 {
+            return None;
+        }
+
+        match &mut self.state {
+            IntoIterState::Done => None,
+            IntoIterState::Inline(iter) => {
+                let item = iter.next();
+                if item.is_some() {
+                    self.remaining -= 1;
+                }
+                item
+            },
+            IntoIterState::Tree(ts) => {
+                if ts.front_pos < ts.front_leaf.len() {
+                    let item = ts.front_leaf[ts.front_pos].clone();
+                    ts.front_pos += 1;
+                    ts.front_index += 1;
+                    self.remaining -= 1;
+                    return Some(item);
+                }
+
+                ts.front_leaf.clear();
+                ts.front_pos = 0;
+                let (slice, offset) = ts.tree.get_leaf_slice(ts.front_index)?;
+                ts.front_leaf.extend(slice[offset..].iter().cloned());
+                if ts.front_leaf.is_empty() {
+                    return None;
+                }
+                let item = ts.front_leaf[0].clone();
+                ts.front_pos = 1;
+                ts.front_index += 1;
+                self.remaining -= 1;
+                Some(item)
+            },
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
+        (self.remaining, Some(self.remaining))
     }
 }
 
-impl<T> ExactSizeIterator for PersistentVectorIntoIter<T> {}
+impl<T: Clone> ExactSizeIterator for PersistentVectorIntoIter<T> {}
 
-impl<T> DoubleEndedIterator for PersistentVectorIntoIter<T> {
+impl<T: Clone> DoubleEndedIterator for PersistentVectorIntoIter<T> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back()
+        if self.remaining == 0 {
+            return None;
+        }
+
+        match &mut self.state {
+            IntoIterState::Done => None,
+            IntoIterState::Inline(iter) => {
+                let item = iter.next_back();
+                if item.is_some() {
+                    self.remaining -= 1;
+                }
+                item
+            },
+            IntoIterState::Tree(ts) => {
+                if let Some(item) = ts.back_leaf.pop() {
+                    ts.back_index -= 1;
+                    self.remaining -= 1;
+                    return Some(item);
+                }
+
+                if ts.back_index == 0 {
+                    return None;
+                }
+
+                let (slice, offset) = ts.tree.get_leaf_slice(ts.back_index - 1)?;
+                ts.back_leaf.extend(slice[..=offset].iter().cloned());
+                let item = ts.back_leaf.pop()?;
+                ts.back_index -= 1;
+                self.remaining -= 1;
+                Some(item)
+            },
+        }
     }
 }

--- a/src/pvec/mod.rs
+++ b/src/pvec/mod.rs
@@ -1,43 +1,33 @@
 //! Persistent vector implementation using RRB (Relaxed Radix Balanced) trees.
 //!
-//! This module provides a persistent, immutable vector data structure that supports
-//! efficient operations for insertion, deletion, and random access. The implementation
-//! uses RRB trees which maintain logarithmic performance characteristics while
-//! supporting efficient concatenation and splitting operations.
+//! Provides an immutable vector data structure with structural sharing, supporting
+//! logarithmic-time updates, access, splitting, and concatenation.
 //!
-//! # Key Features
+//! # Characteristics
 //!
-//! - **Persistence**: All operations return new vectors, leaving the original unchanged
-//! - **Structural Sharing**: Modified vectors share structure with originals, minimizing memory usage
-//! - **Adaptive Storage**: Small vectors (≤64 elements) use inline storage for optimal performance
-//! - **Efficient Operations**: O(log n) for most operations including random access, update, and split
-//! - **Bounded Branches**: Every RRB branch contains at most 32 children, including after concatenation
+//! - **Structural Sharing**: Modifications return new vectors sharing unchanged tree nodes.
+//! - **Adaptive Storage**: Vectors with $\le 64$ elements reside in inline `SmallVec` storage without heap allocation.
+//! - **Tree Invariant**: Branch nodes contain at most 32 children.
+//! - **Lazy Iteration**: `IntoIterator` yields owned values by streaming leaves on demand without full-vector heap allocation.
 //!
 //! # When to Use
 //!
 //! Use `PersistentVector` when you need:
-//! - Immutable data structures with efficient updates
-//! - Version history or undo/redo functionality
-//! - Safe sharing across threads without locks
+//! - Immutable data structures with version history or undo/redo
+//! - Thread-safe sharing without locks
 //! - Functional programming patterns
 //!
-//! For mutable use cases where persistence isn't needed, prefer `Vec<T>`.
+//! For standard mutable sequences, prefer `Vec<T>`.
 //!
-//! # Error Handling Policy
+//! # Error Handling
 //!
-//! This module follows a dual approach to error handling:
-//!
-//! - **Total functions** (e.g., `update`, `get`): Return a default value or `Option`
-//!   when operations cannot complete. This supports functional programming patterns
-//!   where operations should always succeed.
-//!
-//! - **Fallible functions** (e.g., `try_update`, `try_get`): Return `Result` with
-//!   detailed error information via `PVecError`.
+//! - Total functions (`get`, `update`): Return `Option` or the unchanged vector.
+//! - Fallible functions (`try_get`, `try_update`): Return `Result<_, PVecError>`.
 //!
 //! | Operation | Total Version | Fallible Version |
 //! |-----------|---------------|------------------|
 //! | Get element | `get()` → `Option<&T>` | `try_get()` → `Result<&T, PVecError>` |
-//! | Update element | `update()` → `Self` (clone on error) | `try_update()` → `Result<Self, PVecError>` |
+//! | Update element | `update()` → `Self` | `try_update()` → `Result<Self, PVecError>` |
 //!
 //! # Examples
 //!

--- a/src/pvec/node.rs
+++ b/src/pvec/node.rs
@@ -52,7 +52,7 @@ pub(crate) const SMALL_SIZE_TABLE_SIZE: usize = 8;
 /// - Branch nodes use `SmallVec` with inline storage for up to 8 children
 /// - Leaf nodes use `SmallVec` with inline storage for up to 64 elements
 /// - Size tables (when present) also use `SmallVec` with inline storage
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug)]
 pub enum RRBNode<T> {
     /// A branch node containing child nodes.
     ///
@@ -63,7 +63,7 @@ pub enum RRBNode<T> {
         ///
         /// The number of children is bounded by `BRANCHING_FACTOR` (32).
         children: SmallVec<[Arc<RRBNode<T>>; SMALL_BRANCH_SIZE]>,
-        /// Size table containing cumulative sizes of each subtree.
+        /// Size table containing the size of each child subtree.
         sizes: SmallVec<[usize; SMALL_SIZE_TABLE_SIZE]>,
     },
     /// A leaf node containing actual data elements.

--- a/src/pvec/node.rs
+++ b/src/pvec/node.rs
@@ -108,14 +108,7 @@ impl<T> RRBNode<T> {
 
 /// Node transformation and update methods
 impl<T: Clone> RRBNode<T> {
-    pub fn create_branch_result(
-        children: SmallVec<[Arc<RRBNode<T>>; SMALL_BRANCH_SIZE]>,
-        sizes: SmallVec<[usize; SMALL_SIZE_TABLE_SIZE]>, popped: T,
-    ) -> Option<(Self, T)> {
-        Some((RRBNode::Branch { children, sizes }, popped))
-    }
-
-    pub fn update(&self, index: usize, value: T, current_height: usize) -> Self {
+    pub fn update(&self, index: usize, value: T) -> Self {
         match self {
             RRBNode::Leaf { elements } => {
                 let mut new_elements = elements.clone();
@@ -131,8 +124,7 @@ impl<T: Clone> RRBNode<T> {
 
                 if let Some((child_index, sub_index)) = found {
                     if let Some(child) = children.get(child_index) {
-                        let child_height = current_height.saturating_sub(1);
-                        let updated_child = child.update(sub_index, value, child_height);
+                        let updated_child = child.update(sub_index, value);
                         let mut new_children = children.clone();
                         new_children[child_index] = Arc::new(updated_child);
                         RRBNode::Branch {
@@ -159,35 +151,6 @@ impl<T: Clone> RRBNode<T> {
             children: children.into(),
             sizes,
         }
-    }
-
-    pub fn update_size_table_after_removal(
-        sizes: &SmallVec<[usize; SMALL_SIZE_TABLE_SIZE]>, index: usize,
-    ) -> SmallVec<[usize; SMALL_SIZE_TABLE_SIZE]> {
-        let mut new_sizes = sizes.clone();
-        if index < new_sizes.len() {
-            new_sizes.remove(index);
-        }
-        new_sizes
-    }
-
-    pub fn update_size_table_after_update(
-        sizes: &SmallVec<[usize; SMALL_SIZE_TABLE_SIZE]>, index: usize, new_size: usize,
-    ) -> SmallVec<[usize; SMALL_SIZE_TABLE_SIZE]> {
-        let mut new_sizes = sizes.clone();
-        if index < new_sizes.len() {
-            new_sizes[index] = new_size;
-        }
-        new_sizes
-    }
-
-    pub fn create_empty_leaf_result<U>(popped: U) -> Option<(Self, U)> {
-        Some((
-            RRBNode::Leaf {
-                elements: SmallVec::new(),
-            },
-            popped,
-        ))
     }
 
     fn append_size(
@@ -325,20 +288,35 @@ impl<T: Clone> RRBNode<T> {
 
                     if new_child.calculate_size() == 0 {
                         new_children.pop();
-                        let new_sizes =
-                            Self::update_size_table_after_removal(sizes, last_child_index);
-
-                        if new_children.is_empty() {
-                            return Self::create_empty_leaf_result(popped);
+                        let mut new_sizes = sizes.clone();
+                        if last_child_index < new_sizes.len() {
+                            new_sizes.remove(last_child_index);
                         }
 
-                        Self::create_branch_result(new_children, new_sizes, popped)
+                        if new_children.is_empty() {
+                            return Some((
+                                RRBNode::Leaf {
+                                    elements: SmallVec::new(),
+                                },
+                                popped,
+                            ));
+                        }
+
+                        Some((
+                            RRBNode::Branch {
+                                children: new_children,
+                                sizes: new_sizes,
+                            },
+                            popped,
+                        ))
                     } else {
                         new_children[last_child_index] = Arc::new(new_child);
 
                         let new_size = new_children[last_child_index].calculate_size();
-                        let new_sizes =
-                            Self::update_size_table_after_update(sizes, last_child_index, new_size);
+                        let mut new_sizes = sizes.clone();
+                        if last_child_index < new_sizes.len() {
+                            new_sizes[last_child_index] = new_size;
+                        }
 
                         Some((
                             RRBNode::Branch {
@@ -463,18 +441,35 @@ impl<T: Clone> RRBNode<T> {
 
                     if new_child.calculate_size() == 0 {
                         new_children.remove(0);
-                        let new_sizes = Self::update_size_table_after_removal(sizes, 0);
-
-                        if new_children.is_empty() {
-                            return Self::create_empty_leaf_result(popped);
+                        let mut new_sizes = sizes.clone();
+                        if !new_sizes.is_empty() {
+                            new_sizes.remove(0);
                         }
 
-                        Self::create_branch_result(new_children, new_sizes, popped)
+                        if new_children.is_empty() {
+                            return Some((
+                                RRBNode::Leaf {
+                                    elements: SmallVec::new(),
+                                },
+                                popped,
+                            ));
+                        }
+
+                        Some((
+                            RRBNode::Branch {
+                                children: new_children,
+                                sizes: new_sizes,
+                            },
+                            popped,
+                        ))
                     } else {
                         new_children[0] = Arc::new(new_child);
 
                         let new_size = new_children[0].calculate_size();
-                        let new_sizes = Self::update_size_table_after_update(sizes, 0, new_size);
+                        let mut new_sizes = sizes.clone();
+                        if !new_sizes.is_empty() {
+                            new_sizes[0] = new_size;
+                        }
 
                         Some((
                             RRBNode::Branch {

--- a/src/pvec/tree.rs
+++ b/src/pvec/tree.rs
@@ -20,10 +20,10 @@ use super::node::{
 use smallvec::SmallVec;
 use std::sync::Arc;
 
-/// An RRB tree structure for efficient persistent vector operations.
+/// An RRB tree structure for persistent vector operations.
 ///
-/// The RRB tree combines the root tree structure with head and tail buffers
-/// for optimal performance on common operations like `push_back` and `push_front`.
+/// Combines a root tree structure with head and tail buffers for $O(1)$
+/// amortized front and back insertions.
 ///
 /// # Structure
 ///
@@ -36,7 +36,7 @@ use std::sync::Arc;
 /// - `len` equals `head.len() + tree_size + tail.len()`
 /// - `height` reflects the depth of the tree (0 for leaf-only)
 /// - Buffers are flushed to the tree when they reach capacity
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug)]
 pub struct RRBTree<T> {
     /// The root node of the tree structure.
     ///
@@ -65,45 +65,47 @@ pub struct RRBTree<T> {
 
 /// Read-only methods that don't require Clone
 impl<T> RRBTree<T> {
-    /// Gets a reference to the element at the specified index.
-    pub fn get(&self, index: usize) -> Option<&T> {
+    /// Returns the leaf slice containing `index` and the offset within that slice.
+    pub(crate) fn get_leaf_slice(&self, index: usize) -> Option<(&[T], usize)> {
         if index >= self.len {
             return None;
         }
 
         if index < self.head.len() {
-            return self.head.get(index);
+            return Some((self.head.as_slice(), index));
         }
 
         let adjusted_index = index - self.head.len();
         let tree_size = self.len - self.head.len() - self.tail.len();
 
         if adjusted_index < tree_size {
-            self.get_from_tree(adjusted_index)
+            let mut current_node = &self.root;
+            let mut remaining_index = adjusted_index;
+
+            loop {
+                match current_node.as_ref() {
+                    RRBNode::Leaf { elements } => {
+                        return Some((elements.as_slice(), remaining_index));
+                    },
+                    RRBNode::Branch { children, .. } => {
+                        let (child_idx, sub_index) =
+                            current_node.find_child_relaxed(remaining_index)?;
+
+                        current_node = children.get(child_idx)?;
+                        remaining_index = sub_index;
+                    },
+                }
+            }
         } else {
             let tail_index = adjusted_index - tree_size;
-            self.tail.get(tail_index)
+            Some((self.tail.as_slice(), tail_index))
         }
     }
 
-    fn get_from_tree(&self, index: usize) -> Option<&T> {
-        let mut current_node = &self.root;
-        let mut remaining_index = index;
-
-        loop {
-            match current_node.as_ref() {
-                RRBNode::Leaf { elements } => {
-                    return elements.get(remaining_index);
-                },
-                RRBNode::Branch { children, .. } => {
-                    let (child_idx, sub_index) =
-                        current_node.find_child_relaxed(remaining_index)?;
-
-                    current_node = children.get(child_idx)?;
-                    remaining_index = sub_index;
-                },
-            }
-        }
+    /// Gets a reference to the element at the specified index.
+    pub fn get(&self, index: usize) -> Option<&T> {
+        let (slice, offset) = self.get_leaf_slice(index)?;
+        slice.get(offset)
     }
 
     /// Builds a tree by consuming its input without intermediate allocations.

--- a/src/pvec/tree.rs
+++ b/src/pvec/tree.rs
@@ -89,7 +89,6 @@ impl<T> RRBTree<T> {
     fn get_from_tree(&self, index: usize) -> Option<&T> {
         let mut current_node = &self.root;
         let mut remaining_index = index;
-        let mut current_height = self.height;
 
         loop {
             match current_node.as_ref() {
@@ -102,7 +101,6 @@ impl<T> RRBTree<T> {
 
                     current_node = children.get(child_idx)?;
                     remaining_index = sub_index;
-                    current_height = current_height.saturating_sub(1);
                 },
             }
         }
@@ -242,7 +240,7 @@ impl<T: Clone> RRBTree<T> {
         let tree_size = self.len - self.head.len() - self.tail.len();
 
         if adjusted_index < tree_size {
-            let new_root = self.root.update(adjusted_index, value, self.height);
+            let new_root = self.root.update(adjusted_index, value);
             Self {
                 root: Arc::new(new_root),
                 tail: self.tail.clone(),
@@ -570,19 +568,7 @@ impl<T: Clone> RRBTree<T> {
             },
             (RRBNode::Leaf { .. }, RRBNode::Branch { .. })
             | (RRBNode::Branch { .. }, RRBNode::Leaf { .. }) => {
-                let left_as_branch = match left.as_ref() {
-                    RRBNode::Leaf { .. } => vec![left.clone()],
-                    RRBNode::Branch { children, .. } => children.iter().cloned().collect(),
-                };
-
-                let right_as_branch = match right.as_ref() {
-                    RRBNode::Leaf { .. } => vec![right.clone()],
-                    RRBNode::Branch { children, .. } => children.iter().cloned().collect(),
-                };
-
-                let mut all_children = left_as_branch;
-                all_children.extend(right_as_branch);
-                Self::pack_children(all_children)
+                unreachable!("nodes at equal tree height must both be leaves or both branches")
             },
         }
     }
@@ -626,42 +612,23 @@ impl<T: Clone> RRBTree<T> {
     }
 
     fn pop_from_tree(&self) -> Option<(Self, T)> {
-        if self.len == 0 {
-            return None;
-        }
-
         let tree_size = self.len - self.head.len() - self.tail.len();
-        if tree_size == 0 {
-            return None;
+        if tree_size > 0
+            && let Some((new_root, popped)) = self.root.pop_back()
+        {
+            let new_height = if tree_size == 1 { 0 } else { self.height };
+            return Some((
+                Self {
+                    root: Arc::new(new_root),
+                    tail: self.tail.clone(),
+                    head: self.head.clone(),
+                    height: new_height,
+                    len: self.len - 1,
+                },
+                popped,
+            ));
         }
-
-        let last_tree_index = tree_size - 1;
-        let last_element = self.get_from_tree(last_tree_index)?.clone();
-
-        let (new_root, new_height) = if tree_size == 1 {
-            (
-                Arc::new(RRBNode::Leaf {
-                    elements: SmallVec::new(),
-                }),
-                0,
-            )
-        } else {
-            match self.root.pop_back() {
-                Some((new_root, _)) => (Arc::new(new_root), self.height),
-                None => (self.root.clone(), self.height),
-            }
-        };
-
-        Some((
-            Self {
-                root: new_root,
-                tail: self.tail.clone(),
-                head: self.head.clone(),
-                height: new_height,
-                len: self.len - 1,
-            },
-            last_element,
-        ))
+        None
     }
 
     pub fn pop_front(&self) -> Option<(Self, T)> {
@@ -1095,5 +1062,19 @@ mod tests {
         let (tree4, popped) = tree3.pop_front().unwrap();
         assert_eq!(popped, 66);
         assert!(tree4.pop_front().is_none());
+    }
+
+    #[test]
+    fn pop_back_from_tree_single_pass() {
+        let mut tree = RRBTree::from_elements(0..128);
+        assert!(tree.tail.is_empty());
+        for expected in (0..128).rev() {
+            let (next, popped) = tree.pop_back().expect("non-empty");
+            assert_eq!(popped, expected);
+            assert_eq!(next.len, expected as usize);
+            tree = next;
+        }
+        assert_eq!(tree.len, 0);
+        assert!(tree.pop_back().is_none());
     }
 }


### PR DESCRIPTION
## Summary

This pull request optimizes `PersistentVector` traversal, relaxes overly restrictive trait bounds, and refactors iteration and mutation paths for structural sharing and performance:

- **Bound Relaxations**: Relaxed `PersistentVector<T>` `Debug` implementation from `T: Clone + Debug` to `T: Debug` (rendered via `debug_list`), and removed `U: Clone` bounds from `map`, `filter_map`, and `flat_map`.
- **Lazy Iterator Streaming**: Refactored `PersistentVectorIntoIter` to stream leaf slices on demand via `RRBTree::get_leaf_slice`, eliminating eager full-vector heap allocations.
- **Tree Traversal & Fast-paths**: Optimized `pop_from_tree` to consume popped values directly from single-pass `root.pop_back()` without auxiliary $O(\log n)$ lookups; added $O(1)$ boundary fast-paths (`pop_front`/`pop_back`) in `remove`; added in-place `SmallVec` mutation fast-paths for inline vectors ($\le 64$ elements).
- **Structural Sharing & Equality**: Preserved structural sharing in `Extend::extend` using amortized $O(1)$ tail appends; accelerated `PartialEq::eq` with length checks and `Arc::ptr_eq` pointer equality; eliminated intermediate `Vec` allocations in `PersistentVector::chunk`.
- **Internal Cleanups & Deprecations**: Removed misleading structural derives (`PartialEq`, `Eq`, `PartialOrd`, `Ord`, `Hash`) on internal tree types (`VectorImpl`, `RRBTree`, `RRBNode`); deprecated `PVecError::is_index_out_of_bounds` in favor of enum pattern matching; corrected tree height invariant handling in `concat_nodes`.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --all-features --locked`
- [x] Documentation, examples, and benchmarks were updated if needed.
- [x] `CHANGELOG.md` was updated for user-visible changes.

## API and compatibility

- [ ] This change does not alter the public API.
- [x] If the public API changed, migration notes and compatibility impact are documented.

### Compatibility Notes
- **Backward Compatible**: Trait bounds on `PersistentVector` methods (`map`, `filter_map`, `flat_map`) and `Debug` were relaxed, broadening caller compatibility without breaking existing call sites.
- **Deprecation**: `PVecError::is_index_out_of_bounds` is marked deprecated (`#[deprecated(since = "0.16.0")]`) in favor of direct pattern matching on `PVecError::IndexOutOfBounds { .. }`.